### PR TITLE
Merge pull request #6259 utils/kata-manager.sh

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -238,23 +238,6 @@ Advice:
 EOF
 }
 
-# Determine if the system only supports cgroups v2.
-#
-# - Writes "true" to stdout if only cgroups v2 are supported.
-# - Writes "false" to stdout if cgroups v1 or v1+v2 are available.
-# - Writes a blank string to stdout if cgroups are not available.
-only_supports_cgroups_v2()
-{
-	local v1=$(mount|awk '$5 ~ /^cgroup$/ { print; }' || true)
-	local v2=$(mount|awk '$5 ~ /^cgroup2$/ { print; }' || true)
-
-	[ -n "$v1" ] && [ -n "$v2" ] && { echo "false"; return 0; } || true
-	[ -n "$v1" ] && { echo "false"; return 0; } || true
-	[ -n "$v2" ] && { echo "true"; return 0; } || true
-
-	return 0
-}
-
 # Return 0 if containerd is already installed, else return 1.
 containerd_installed()
 {
@@ -279,13 +262,6 @@ pre_checks()
 	{ containerd_installed; ret=$?; } || true
 
 	[ "$ret" -eq 0 ] && die "$containerd_project already installed"
-
-	local cgroups_v2_only=$(only_supports_cgroups_v2 || true)
-
-	local url="https://github.com/kata-containers/kata-containers/issues/927"
-
-	[ "$cgroups_v2_only" = "true" ] && \
-		die "$kata_project does not yet fully support cgroups v2 - see $url"
 
 	return 0
 }


### PR DESCRIPTION
Removed the part in the `kata-manager.sh` script that checked if the host machine only supported cgroups v2.

Issue #6259

Alec Pemberton <pembek1901@gmail.com>